### PR TITLE
create a package

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Python Evaluation Code for [Wider Face Dataset](http://mmlab.ie.cuhk.edu.hk/proj
 installation from github
 
 ````
-pip install git+https://github.com/msinamsina/WiderFace-Evaluation.git
+git clone <URLL>
+cd WiderFace-Evaluation
+pip install .
 ````
 
 ##### evaluating

--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ Python Evaluation Code for [Wider Face Dataset](http://mmlab.ie.cuhk.edu.hk/proj
 
 ##### before evaluating ....
 
+installation from github
+
 ````
-python3 setup.py build_ext --inplace
+pip install git+https://github.com/msinamsina/WiderFace-Evaluation.git
 ````
 
 ##### evaluating

--- a/box_overlaps.pyx
+++ b/box_overlaps.pyx
@@ -9,7 +9,7 @@ cimport cython
 import numpy as np
 cimport numpy as np
 
-DTYPE = np.float
+DTYPE = float
 ctypedef np.float_t DTYPE_t
 
 def bbox_overlaps(

--- a/box_overlaps.pyx
+++ b/box_overlaps.pyx
@@ -8,9 +8,8 @@
 cimport cython
 import numpy as np
 cimport numpy as np
-
-DTYPE = float
-ctypedef np.float_t DTYPE_t
+ctypedef float DTYPE_t
+DTYPE = np.float32
 
 def bbox_overlaps(
         np.ndarray[DTYPE_t, ndim=2] boxes,

--- a/evaluation.py
+++ b/evaluation.py
@@ -1,18 +1,10 @@
-"""
-WiderFace evaluation code
-author: wondervictor
-mail: tianhengcheng@gmail.com
-copyright@wondervictor
-"""
-
 import os
 import tqdm
 import pickle
 import argparse
 import numpy as np
 from scipy.io import loadmat
-from bbox import bbox_overlaps
-from IPython import embed
+from widerface_eval.bbox import bbox_overlaps
 
 
 def get_gt_boxes(gt_dir):

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,32 @@
-"""
-WiderFace evaluation code
-author: wondervictor
-mail: tianhengcheng@gmail.com
-copyright@wondervictor
-"""
+from setuptools import setup, Extension
+import subprocess
+import sys
 
-from distutils.core import setup, Extension
+
+def install(package):
+    subprocess.check_call([sys.executable, "-m", "pip", "install", package])
+
+
+install('cython')
+install('numpy')
+
 from Cython.Build import cythonize
 import numpy
 
-package = Extension('bbox', ['box_overlaps.pyx'], include_dirs=[numpy.get_include()])
-setup(ext_modules=cythonize([package]))
+
+package = Extension('widerface_eval.bbox', ['box_overlaps.pyx'], include_dirs=[numpy.get_include()])
+setup(
+    name='widerface-eval',
+    version='1.0',
+    description='Evaluation code for WIDER FACE',
+    ext_modules=cythonize(package),
+    package_dir={'widerface_eval': ''},
+    py_modules=['widerface_eval.evaluation'],
+    install_requires=[
+        'Cython',
+        'numpy',
+        'scipy',
+        'argparse',
+        'tqdm',
+    ],
+)


### PR DESCRIPTION
In this update, setup.py is modified and it can be installed using pip.
additionally, a bug is fixed: the Numpy package doesn't have a `float` attribute in the new version of it.  you can use `np.float32` instead of  `np.float` in box_overlaps.pyx.